### PR TITLE
feat: implement single-tab chrome extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,104 @@
+/**
+ * This is the background service worker for the Single Tab extension.
+ * It enforces the rule that only one tab can be open at a time.
+ */
+
+// This is the core function to enforce the single tab rule.
+async function enforceSingleTab() {
+  // Get all tabs across all windows.
+  const allTabs = await chrome.tabs.query({});
+
+  // If 0 or 1 tab, nothing to do. If 1, just store its ID.
+  if (allTabs.length <= 1) {
+    if (allTabs.length === 1) {
+        chrome.storage.local.set({ singleTabId: allTabs[0].id });
+    }
+    return;
+  }
+
+  // More than one tab exists. We must close the extras.
+  let tabToKeep = null;
+  const result = await chrome.storage.local.get('singleTabId');
+  const storedTabId = result.singleTabId;
+
+  // 1. Check if the stored tab is still open.
+  if (storedTabId) {
+    tabToKeep = allTabs.find(t => t.id === storedTabId);
+  }
+
+  // 2. If stored tab is gone, try to keep the currently active tab.
+  if (!tabToKeep) {
+    tabToKeep = allTabs.find(t => t.active);
+  }
+
+  // 3. If no tab is active (can happen), just pick the first one in the array.
+  if (!tabToKeep) {
+    tabToKeep = allTabs[0];
+  }
+
+  // Store the ID of the tab we are keeping.
+  chrome.storage.local.set({ singleTabId: tabToKeep.id });
+
+  // And close all other tabs.
+  const tabsToCloseIds = allTabs
+    .filter(t => t.id !== tabToKeep.id)
+    .map(t => t.id);
+
+  await chrome.tabs.remove(tabsToCloseIds);
+}
+
+// This function handles the edge case where the browser starts with zero tabs.
+async function ensureAtLeastOneTab() {
+    const tabs = await chrome.tabs.query({});
+    if (tabs.length === 0) {
+        const newTab = await chrome.tabs.create({});
+        chrome.storage.local.set({ singleTabId: newTab.id });
+    }
+}
+
+// --- Event Listeners ---
+
+// On extension install, run the enforcement logic.
+chrome.runtime.onInstalled.addListener(() => {
+  console.log("Single Tab extension installed/updated.");
+  enforceSingleTab();
+});
+
+// On browser startup, ensure we have at least one tab and then enforce the rule.
+chrome.runtime.onStartup.addListener(() => {
+    console.log("Browser started.");
+    ensureAtLeastOneTab();
+    enforceSingleTab();
+});
+
+// When a new tab is created, run the enforcement logic.
+// This is the primary event that triggers the one-tab rule.
+chrome.tabs.onCreated.addListener((tab) => {
+    enforceSingleTab();
+});
+
+// Listen for messages from the content script.
+chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
+  if (request.action === "openInSameTab" && request.url) {
+    const result = await chrome.storage.local.get('singleTabId');
+    const tabIdToUpdate = result.singleTabId;
+
+    if (tabIdToUpdate) {
+      try {
+        // Try to update the one and only tab.
+        await chrome.tabs.update(tabIdToUpdate, { url: request.url });
+      } catch (error) {
+        // This can happen if the tab was closed. Create a new one.
+        console.error(`Failed to update tab ${tabIdToUpdate}:`, error);
+        const newTab = await chrome.tabs.create({ url: request.url });
+        chrome.storage.local.set({ singleTabId: newTab.id });
+        enforceSingleTab(); // Clean up any other tabs that might have appeared.
+      }
+    } else {
+      // This should be rare, but if we have no tab ID, create a new tab.
+      const newTab = await chrome.tabs.create({ url: request.url });
+      chrome.storage.local.set({ singleTabId: newTab.id });
+      enforceSingleTab(); // Clean up any others.
+    }
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,53 @@
+/**
+ * This content script is injected into every page.
+ * Its purpose is to prevent new tabs from being opened from the page's content.
+ */
+
+// --- 1. Intercept window.open() ---
+// Some websites use window.open() to create popups or new tabs.
+// We override it to redirect the URL to our background script,
+// which will open it in the single existing tab.
+const originalWindowOpen = window.open;
+window.open = function(url, name, features) {
+  console.log(`Single Tab: Intercepted window.open call for URL: ${url}`);
+  if (url) {
+    chrome.runtime.sendMessage({
+      action: "openInSameTab",
+      url: url
+    });
+  }
+  // Return null to prevent the original window from being opened.
+  return null;
+};
+
+
+// --- 2. Modify links with target="_blank" ---
+// Links with `target="_blank"` are designed to open in a new tab.
+// We need to change them to `target="_self"` to open in the same tab.
+
+function modifyLinks() {
+  const links = document.querySelectorAll('a[target="_blank"]');
+  links.forEach(link => {
+    link.target = '_self';
+  });
+}
+
+// Run the function once the initial DOM is loaded.
+modifyLinks();
+
+// --- 3. Handle dynamically added content ---
+// Modern websites often load content dynamically. A MutationObserver
+// allows us to react to changes in the DOM and modify new links as they are added.
+const observer = new MutationObserver((mutationsList, observer) => {
+  for (const mutation of mutationsList) {
+    if (mutation.type === 'childList') {
+      // A new node was added, so we re-run our link modification logic.
+      modifyLinks();
+    }
+  }
+});
+
+// Start observing the entire document body for changes.
+observer.observe(document.body, { childList: true, subtree: true });
+
+console.log("Single Tab content script loaded and active.");

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "Single Tab",
+  "version": "1.0",
+  "description": "This extension enforces a single tab policy in Chrome.",
+  "permissions": ["tabs", "storage"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ],
+  "action": {
+    "default_title": "Single Tab"
+  }
+}


### PR DESCRIPTION
This commit introduces a complete Chrome extension to enforce a single-tab browsing policy.

The extension consists of three main components:
- `manifest.json`: Configures the extension for Manifest V3, setting up permissions for tabs and storage, and registering the background service worker and content script.
- `background.js`: The core logic that runs as a service worker. It listens for tab creation and browser startup events to enforce the single-tab rule by closing any excess tabs. It maintains the ID of the single tab in storage for persistence. It also handles messages from the content script to redirect navigation.
- `content.js`: A script injected into all web pages. It prevents pages from opening new tabs by overriding `window.open()` and by modifying links with `target="_blank"` to open in the same tab. It uses a `MutationObserver` to handle dynamically loaded content.